### PR TITLE
RBF FAQ: "polish" with heavy-handed copyediting

### DIFF
--- a/_posts/en/pages/faq/2016-01-21-rbf-faq.md
+++ b/_posts/en/pages/faq/2016-01-21-rbf-faq.md
@@ -1,5 +1,5 @@
 ---
-### orinally sourced from https://www.reddit.com/r/Bitcoin/comments/3urm8o/optin_rbf_is_misunderstood_ask_questions_about_it/
+### Originally sourced from https://www.reddit.com/r/Bitcoin/comments/3urm8o/optin_rbf_is_misunderstood_ask_questions_about_it/
 title: Opt-in RBF FAQ
 name: optin-rbf-faq
 type: page
@@ -8,107 +8,248 @@ share: true
 ---
 {% include _toc.html %}
 
-##What is Opt-in RBF?
+## What is opt-in RBF?
 
-Opt-in RBF (replace-by-fee) means transactions can be explicitly marked as replaceable and making it clear to the receiver.
+During the period when transactions are waiting to be added to a block,
+some wallets would like to be able to update those transactions in order
+to increase their fee (which may help them get confirmed faster), add
+new outputs (possibly compressing what would be multiple transactions
+into a single transaction), create background coinjoins (to improve
+privacy), or to perform a number of other useful actions.
 
-##Does the opt-in RBF implementation change the likelihood that a "non-RBF" (max value nSequence) transaction can be double-spent?
+Opt-in Replace-by-Fee (RBF) is a change to memory pool and network relay
+code that allows those wallets to optionally add a signal to their
+transactions which tells full nodes that those particular transactions
+may be updated (replaced) up until the point that they get confirmed in
+a new block.
 
-No.  A transaction must be marked replaceable (sequence number *below* MAX*-1*) to be replaceable.
+## Does the opt-in RBF implementation change the likelihood that a "non-RBF" transaction can be double-spent?
 
-## Does Opt-in RBF make fraudulent spends significantly more successful?
+No.  A transaction must be marked replaceable (sequence number *below* MAX*-1*)
+in order for the opt-in RBF implementation to treat it as replaceable.
 
-Opt-in RBF has no effect on transactions which are not using it and no one is forced to use it. Opt-in RBF has no effect once a transaction has been confirmed. Users who care about unconfirmed transaction can continue to not use RBF.
+## Does opt-in RBF make fraudulent spends significantly more successful?
 
-Even so, An interesting alternative question is "Are Opt-in transactions themselves more useful tools to dedicated fraudsters, assuming people accept them without confirmation?"
+Opt-in RBF has no effect on transactions which are not using it and no one is forced to use it. It has no effect once a transaction has been confirmed. This means that users who care about unconfirmed transaction can continue to not use RBF.
 
-We currently do not have reason to believe that they are, at least not significantly, against fraudsters using the most effective tools and practices known. But if they are (or until it is more clear that they are not) recipients can protect themselves by continuing to regard them as unsafe until they become confirmed. This response is especially appropriate because the ability to replace means that there is no risk of sender-unwanted very long confirmation days.
+## Are opt-in transactions themselves more useful tools to dedicated fraudsters, assuming people accept them without confirmation?
 
-In an asynchronous distributed system there is no such thing as a globally consistent "first". What you saw first someone else can and often will see second. And in the Bitcoin design memory pools are not convergent: time passing does not make mempools more consistent.  Sophisticated double spending attackers today use tools to map the network connectivity by making harmless looking conflicting spends and seeing which versions show up at which merchants and in which blocks. When they double spend they can concurrently announce their conflicting self payment to some miners while sending the merchant payment to everyone else. The presence of the non-replaceable merchant payment prevents nodes from learning the double-spend, concealing it from the merchant's observation-- until it shows up in a block, placed by a miner that was merely mining the thing they saw first. This simple, common pattern is sometimes further amplified by additional techniques like using unconfirmed transaction chains, low fees, or non-standard transactions.
+We currently do not have reason to believe that they are, at least not significantly, against fraudsters using the most effective tools and practices known. But if they are (or until it is more clear that they are not) recipients can protect themselves by continuing to regard transactions with non-max sequence numbers as unsafe until they become confirmed.
 
-As a result the vast majority of the security for unconfirmed transactions comes not from within the Bitcoin system, but from factors like the customer's unwilliness to defraud, the vendors tolerance for small amounts of fraud, the existence of the possibility of external recourse, etc. all of which hold true for Opt-In RBF (And not unlike the situation for credit card payments in the US-- they're almost perfectly reversible for _months_). Also, because RBF can sometimes eliminate long confirmation delays, some uses which previously felt forced to accept unconfirmed transaction will no longer need to do so, which reduces their fraud exposure.
+Because spenders who use opt-in RBF have the ability to increase their
+fees and possibly reduce their confirmation time even when there are
+many transactions waiting to confirm, it's not inconsiderate to
+require that their transactions be confirmed before providing them
+with services.
 
-However, no one using Opt-in RBF is insisting that you agree with the above view on unconfirmed transaction security. Opt-in RBF is Opt-in, and if it doesn't fit your needs you are not required to use it.
+## Why aren't unconfirmed transactions safe?
+
+Bitcoin transactions are relayed across an asynchronous distributed
+system where there is no such thing as a globally consistent "first".
+What Alice saw first, Bob might see second.  The Bitcoin design
+doesn't provide a mechanism for Alice and Bob to come to agreement about
+which of those transactions really came first; all they can do is wait
+to see which of those transactions gets confirmed in a valid block on
+the best block chain.
+
+Sophisticated double spending attackers today use tools to map the
+network connectivity by making harmless looking conflicting spends and
+seeing which versions show up at which merchants and in which blocks.
+This allows them to craft two versions of the same transaction, one
+which they send to their victim and one which they send to miners for
+confirmation.
+
+The presence of the non-replaceable payment to the merchant prevents his
+node from learning about the a double-spend until it shows up in a block
+mined by a miner that was merely mining the thing they saw first. This
+simple, common pattern is sometimes further amplified by additional
+techniques such as using unconfirmed transaction chains, low fees, or
+non-standard transactions.
+
+As a result, the vast majority of the security for unconfirmed
+transactions comes not from within the Bitcoin system, but from external
+factors such as the large numbers of honest Bitcoin users who would
+never attempt to defraud their vendors, the tolerance among vendors for
+small amounts of fraud, the ability (or threat) of vendors resorting to
+the legal system or other types of recourse, and other factors which
+have nothing to do with the design of the Bitcoin protocol.
+
+All of these things hold equally true for opt-in RBF (and they're not
+unlike the situation with credit card payments in the US, which are
+easily reversable for months after the exchange and yet which have fraud
+rates low enough that almost all significant merchants accept them).
+Also, because RBF can sometimes eliminate long confirmation delays, some
+merchants which previously felt forced to accept unconfirmed transactions
+to prevent unfortunate delays will no longer need to do so, which reduces
+their exposure to fraud.
+
+However, no one using opt-in RBF is insisting that you agree with the
+above view on unconfirmed transaction security. Opt-in RBF is *opt-in*,
+and if it doesn't fit your needs you are not required to use it.
 
 ## Who invented unconfirmed transaction replacement? Does it go against the "vision" of Bitcoin?
 
-Transaction replacement for unconfirmed transactions was [a feature in the very first release of Bitcoin](https://github.com/trottier/original-bitcoin/blob/master/src/main.cpp#L434).  Transactions could mark themselves as replaceable by setting a non-maximal sequence number. This was later disabled because it was vulnerable to denial of service attacks.
+Transaction replacement for unconfirmed transactions was [a feature in the very first release of Bitcoin](https://github.com/trottier/original-bitcoin/blob/master/src/main.cpp#L434).  Transactions could mark themselves as replaceable by setting a non-maximal sequence number. This was later disabled because it was possible
+for an attacker to use up all the bandwidth among full nodes at only a
+small cost to himself, creating a denial-of-service vulnerability.
 
-Although the feature was very useful the denial of service problems and the fact that it was not incentive compatible (What incentive would miners follow the convention and accept a replacement?-- what if they made more from the earlier version?) kept it from being restored.
+In addition, there was no incentive for miners to follow the convention
+and accept a replacement, and there could even be an incentive to
+violate the convention if an earlier version of a transaction paid a
+higher fee.
 
-Later Peter Todd proposed requiring replacements to pay strictly greater feerate and to require that the replacement increase the feerate by at least the minimum required to relay a new transaction. This both eliminated the denial of service and incentive compatibility problems.
+These two factors kept replacement from being restored for several
+years, but in 2013 Peter Todd
+[proposed](https://bitcointalk.org/index.php?topic=199947.0) requiring
+replacements to pay a strictly greater fee rate and to require that the
+replacement increase the fee rate by at least the minimum required to
+relay a new transaction. This eliminated both the denial of service and
+incentive compatibility problems.
 
-Peter's original work went further and carried the incentive compatibility to its logical conclusion, reasoning that with anonymous, ephemeral, self-selecting miners the only behavior you can really count on is replacement with higher fees. Higher fee preference can also be made more globally convergent than seen first, because there is no global definition of 'first' in an asynchronous distributed system. Because of these reasons and because the system behaving in expected ways is more secure and protective than the system behaving in "unpredictable but better on average ways", he proposed making replacement happen for all transactions. He also proposed a protocol to remove economic gains from double spending in a strong incentive compatible way, called replacement scorched earth-- if someone attempts to double spend you, you send the funds all to fees so the attacker doesn't get them, but it was the kind of proposal only a game theorist could really love. After Peter's proposal, we heard a number of wallets call very strongly for opt-in RBF, as they really needed a reasonable way to handle fees and saw opt-in RBF as a good way to do so which is why the proposal was changed to Satoshi's original opt-in behavior. 
+Peter's original work went further and carried the incentive
+compatibility to its logical conclusion, reasoning that with anonymous,
+ephemeral, self-selecting miners the only behavior you can really count
+on is replacement with higher fees. Higher fee preference can also make
+it possible for nodes to converge on a set of transactions in the memory
+pool based on fee rate in a way that isn't possible for nodes which only
+accept the first version of a transaction that they see.
 
-##Was the Opt-in RBF Pull-req controversial?
+Because of these reasons and because the system behaving in expected
+ways is more secure and protective than the system behaving in
+"unpredictable but better on average ways", he proposed making
+replacement happen for all transactions. He also proposed a protocol
+to remove economic gains from double spending in a strong incentive
+compatible way, called replacement scorched earth, where if someone
+attempts to double spend you, you spend all the funds to fees so the
+attacker doesn't get them.  (But this is the kind of proposal only a
+game theorist could really love.)
 
-Not in the slightest. After extensive informal discussion stemming back months the [PR](https://github.com/bitcoin/bitcoin/pull/6871) was opened on October 22nd. It was subsequently discussed in at least four bitcoin development weekly meetings ([2015-11-06](https://bitcointalk.org/index.php?topic=1253158.0), [2015-11-12](https://bitcointalk.org/index.php?topic=1253163.0), [2015-11-19](https://bitcointalk.org/index.php?topic=1260514.0), and 2015-11-26).
+After Peter's proposal, we heard a number of wallets call very strongly
+for opt-in RBF, as they really needed a reasonable way to handle fees
+and saw opt-in RBF as a good way to do so which is why the proposal was
+changed to match Satoshi's original opt-in behavior.
 
-In the PR discussion, 19 people commented (including people working on at least three different wallet brands) and 14 people explicitly ACKed the change, including at least one person who had been very outspoken in the past against full RBF.  No clearly negative feedback was provided in the PR (or elsewhere that I am aware of) whatsoever.
+## Was the opt-in RBF pull request controversial?
+
+Not in the slightest. After extensive informal discussion stemming back
+months, the [PR][RBF PR] was opened on October 22nd. It was subsequently
+discussed in at least four Bitcoin development weekly meetings
+([2015-11-05][], [2015-11-12][], [2015-11-19][], and [2015-11-26][]).
+
+[RBF PR]: https://github.com/bitcoin/bitcoin/pull/6871
+[2015-11-05]: /en/meetings/2015/11/05/
+[2015-11-12]: /en/meetings/2015/11/12/
+[2015-11-19]: /en/meetings/2015/11/19/
+[2015-11-26]: /en/meetings/2015/11/26/
+
+In the PR discussion, 19 people commented (including people working on at least three different wallet brands) and 14 people explicitly ACKed the change, including at least one person who had been very outspoken in the past against full RBF.  No clearly negative feedback was provided in the PR (or elsewhere that we are aware of) while the PR was open.
 
 ## When and how does this change get activated?
 
-Opt-in RBF doesn't really have an "activation", it's not a part of Bitcoin's consensus; it's a local policy behavior and the change happens one node at a time, as people adopt software that behaves differently.  There are already some nodes on the network which RBF in various ways and there have been for some time (years?).
+Opt-in RBF doesn't really have an "activation" because it's not a part of Bitcoin's consensus. It's a local policy behavior and so the change happens one node at a time as people adopt software that behaves differently.  There are already some nodes on the network which perform RBF in various ways and there have been for some time, probably years.
 
-Bitcoin Core 0.12 will be released in a couple months (exact timing depends on how testing progress goes) and will include Opt-in RBF, and after that it will likely take a couple additional months before the behavior is commonplace. This may be sped up by the development of applications that make interesting use of it.
+Bitcoin Core 0.12 will be released around February 2016 and will include opt-in RBF, and after that it will likely take a couple additional months before the behavior is commonplace. This may be sped up by the development of applications that make interesting use of it.
 
-## Is Opt-in RBF only useful for adjusting fees?
+## Is opt-in RBF only useful for adjusting fees?
 
-No, Opt-in RBF can also be used to make low-priority transactions much more efficient by revising them to pay multiple parties when the sender finds they have more parties to pay and their last payment hasn't confirmed yet, or when they find they need to increase the payment amount for a party they are already paying. This also lets transaction authors avoid spending unconfirmed change.
+No, opt-in RBF can also be used to make slow-to-confirm transactions much more efficient by revising them to pay multiple people when the sender finds they have more people to pay and their last payment hasn't confirmed yet, or when they find they need to increase the payment amount for a person they are already paying. This also lets transaction authors avoid spending unconfirmed change, which is currently vulnerable to third-party malleability.
 
-Opt-in RBF can also be used to implement more advanced cooperative scability schemes such as [transaction cut-through](https://bitcointalk.org/index.php?topic=281848.0).
+Opt-in RBF can also be used to implement more advanced cooperative stability schemes such as [transaction cut-through](https://bitcointalk.org/index.php?topic=281848.0).
 
 Various [smart contract](https://bitcointalk.org/index.php?topic=321228.0) cases also need replacement, but they usually use locktime to create stronger ordering and work around the historic unavailability of replacement; these were presumably the motivation for supporting replacement in the Bitcoin protocol in its original design.
 
-The ability to adjust means that the initial fee can use a lower "most likely" estimate instead of having to over-pay just in case; resulting in lower fees even when replacements are rarely made.
+Although interesting for more reasons than just adjusting fees, the
+ability to adjust fees should not be understated. It means that the
+initial fee can use a lower "most likely" estimate instead of having to
+over-pay "just in case"; this results in lower fees even when replacements
+are rarely made.
 
-##Would a wallet need to stay online to issue replacements with higher fees?
+## Would a wallet need to stay online to issue replacements with higher fees?
 
-No. Replacements can be pre-computed and time locked, though software making use of RBF hasn't been written yet.
+No. Replacements can be pre-computed, time locked, and given to an
+always-online remote server for later broadcast with no risk that the
+server could steal any user funds (at worst it could fail to broadcast).
 
 For example. At block 100 a wallet wants to make a transaction set to confirm within 3 blocks. The wallet authors a transaction locked at 101 with its best estimate of a three block confirmation fee, at the same time it also authors replacement transactions locktimed for heights 104, 105, 106, 107... each paying (say) 1.5x the fee of the last. These can be handed to a node that accepts advanced locktime transactions.
 
-Even if miners know higher fees will be paid in the future, rationally they still prefer the one they can include now, since if they wait another miner will likely take the fees. The multiplicative increase suggested above means that at worst a transaction would overpay by 50%, but can still reach arbitrarily high fees in few transactions.
+Even if miners know higher fees will be paid in the future, rationally they still prefer the one they can include now---since, if they wait, another miner will likely take the fees. The multiplicative increase suggested above means that, at worst, a transaction would overpay by 50%, but can still reach arbitrarily high fees in few transactions.
 
-##Does Opt-in RBF increase the risk that "lazy" transaction processors will get scammed?
+## Does opt-in RBF increase the risk that "lazy" transaction processors will get scammed?
 
-It doesn't appear to be so, at least not significantly and this is by design. Opt-In RBF is signaled using the sequence field for transaction which is specifically intended to cover replaceability. Many things trusting unconfirmed transactions already regard low sequence numbered transactions as suspect and ignore them until they confirm. 
+It doesn't appear to be so, at least not significantly and this is by
+design. Opt-In RBF is signaled using the nSequence field, a field that
+is specifically intended to cover replaceability. Many programs and
+platforms that trust unconfirmed transactions in general already regard
+low sequence numbered transactions as suspect and ignore them until
+they confirm.
 
-There are dozens of other ways that transactions can change their speed or reliably of confirmation and aid double spending: Paying low fee, using non-standard flags or versions, spending unconfirmed inputs, behaving like any number of DOS attack patterns, creating dust txouts, etc. These criteria are frequently shipping and depend on node specific policy that is configurable by users. Parties attempting to estimate the risk of an unconfirmed payment must track all these things and more, which are constantly shifting. Opt-in RBF is a highly communicated addition known months in advance, that overlays on already detected behavior. If there is any change in the efforts required for unconfirmed transaction vigilance, it's likely in the noise.
+There are dozens of other ways that transactions can change their speed
+or reliability of confirmation and increase the probability of a
+successful fraudulent double spend:
 
-Beyond that, it's unclear that an RBF Opted-in transaction will actually be significantly more vulnerable to double spending than non-RBF ones, at least against attackers with sophisticated tools.
+- paying low fee
+- using non-standard flags or versions
+- spending unconfirmed inputs
+- behaving like any number of denial-of-service attack patterns
+- creating dust txouts
+- etc.
 
-Some parties that perform unconfirmed confidence analysis have clearly indicated that they're ready for it: https://twitter.com/BlockCypher/status/670334879565922304  ... and if anyone is aware of software that still needs help adapting, let me know and I'd be glad to help.
+These criteria are frequently changing and depend on node specific
+policy that is configurable by users. Parties attempting to estimate the
+risk of an unconfirmed payment must track all these things and more, and
+they must be proactive in responding to changes. Opt-in RBF is a highly
+communicated addition known months in advance that overlays on already
+detected behavior. If there is any change in the efforts required for
+unconfirmed transaction vigilance, it's likely in the noise.
 
-##What if I think that RBF is just awful?
+Beyond that, it's unclear that an opt-in RBF transactions will actually
+be significantly more useful for fraudulent double spending than non-RBF
+ones, at least when used by attackers with sophisticated tools.
 
-Then don't use it: Don't set it on your own transactions and treat transactions you receive with all sequence numbers < MAX_INT-1 as non-existing (or already double-spent) until they confirm. Opt-in RBF is Opt-in.
+Some parties that perform unconfirmed confidence analysis have clearly
+indicated that [they're ready for it][blockcypher ready], and if anyone
+is aware of software that still needs help adapting, let us know and we'd
+be glad to help.
 
-No commonly used software that I'm aware of sets its sequence numbers to below MAX_INT-1, and many programs (including "transaction confidence" meters) already regard low sequence numbers as potentially double spendable. After all, the transaction has been explicitly marked as replaceable, and even without RBF, nlocktime may result in a conflict getting confirmed first.
+[blockcypher ready]: https://twitter.com/BlockCypher/status/670334879565922304
 
-If someone sends you a replaceable transaction and you won't zero-conf credit it, their replacement can make it get confirmed as fast as they want it to get confirmed. The same sorts of situations exist already for senders using non-standard transaction features or spending unconfirmed outputs, which transactions objectively more double spendable, but in those cases there is no fix to get the transaction through quickly. 
+## What if I think that RBF is just awful?
+
+Then don't use it: don't set it on your own transactions and treat transactions you receive with all sequence numbers less
+than MAX_INT-1 as non-existing (or already double-spent) until they confirm. Opt-in RBF is opt-in.
+
+No commonly used software that we're aware of sets its sequence numbers to below MAX_INT-1, and many programs (including "transaction confidence" meters) already regard low sequence numbers as potentially double spendable. After all, the transaction has been explicitly marked as replaceable, and even without RBF, nLocktime may result in a conflict getting confirmed first.
+
+If someone sends you a replaceable transaction and you won't zero-conf credit it, their replacement can make it get confirmed as fast as they want it to get confirmed. The same sorts of situations exist already for senders using non-standard transaction features or spending unconfirmed outputs, which makes transactions objectively more double spendable---but in those cases there is no fix to get the transaction through quickly.
 
 RBF is a feature for consenting adults. If you don't want to participate in it, you don't need to. Your dislike of it isn't a reason to prevent others from using it in transactions that don't involve you.
 
-Many people believe common dislikes of RBF are likely ill-founded and that non-RBF is unreliable and unsafe, but you shouldn't mistake their explanations for an argument that you have to use it.
+## Why implement 'opt-in' and not just let miners replace any transaction?
 
-##Q: Why implement 'opt-in' and not just let miners go with straight up (full) RBF?
+Nothing stops miners from replacing even non-opt-in transactions right now,
+and some miners have previously experimented with RBF on their own.  By
+providing a standard implementation that can fulfill user demand for
+this feature, it's possible there will be less incentive for miners to
+begin replacing any transaction with higher fee rate variants.
 
-Nothing actually stops miners from doing full RBF on txns right now without the opt in sequence no. flag. Are we just trusting miners here to play fair with this flag given it can't (currently) be enforced through consensus validation via CPFP or other schemes? If so it would rather be easier to just acknowledge RBF is here to stay and then no coding is required to Bitcoin Core.
-
-##I heard Opt-in RBF was added with little or no discussion
+## I heard Opt-in RBF was added with little or no discussion
 
 Recent RBF discussions going back to May 2015.
 
 Github:
+
 - Add first-seen-safe replace-by-fee logic to the mempool [#6176](https://github.com/bitcoin/bitcoin/pull/6176)
 - Scheduled full-RBF deployment [#6352](https://github.com/bitcoin/bitcoin/pull/6352)
 - nSequence-based Full-RBF opt-in [#6871](https://github.com/bitcoin/bitcoin/pull/6871)
 
-IRC meeting:
-https://www.reddit.com/r/Bitcoin/comments/3t1in5/bitcoin_dev_irc_meeting_in_laymans_terms_20151112/
+IRC meetings:
 
-There are many other logs which can be found at http://bitcoinstats.com/ for #bitcoin-dev and https://botbot.me/freenode/bitcoin-core-dev/ for #bitcoin-core-dev
+- [2015-11-05][]
+- [2015-11-12][]
+- [2015-11-19][]
+- [2015-11-26][]
+
+There are many other logs for [#bitcoin-dev](http://bitcoinstats.com/) and [#bitcoin-core-dev](https://botbot.me/freenode/bitcoin-core-dev/).
 
 Mailing list discussions in no particular order:
 
@@ -125,111 +266,40 @@ but this was disabled due to a DOS attack (which Peter Todd fixed by requiring a
 
 ## Can this be used to double spend against unprepared (old) wallets? Will all wallets have to update?
 
-> Can this be used to double spend against unprepared (old) wallets?
+Unconfirmed transactions can always be double spent, with or without RBF. Fraud
+is currently easy, and RBF doesn't change that.
 
-Unconfirmed transactions can always be double spent, with or without RBF. RBF doesn't make fraud any easier (it's already easy), only legitimate double spending. So the answer is "yes", but it was already "yes" before RBF, and there is nothing wallets can do to change it to a "no" either way.
+Wallets only have to update if they want to make use of opt-in RBF. This
+gives wallets a new dimension along which they can innovate and provide
+beneficial features to users.
 
-> Will all wallets have to update?
+## Why not First-seen-safe Replace-by-fee (FSS-RBF)
 
-Only to make use of it. This opens up a lot of room to improve wallets.
+FSS-RBF means that transactions can only be modified if all previous
+outputs are fully spent. This prevents double spends, but it has three
+problems when it actually gets used:
 
-## Why not FSS-RBF? (First-seen-safe Replace-by-fee)
+1. It results in increased transaction size because you must add a new
+   input to each replacement.
 
-First-seen-safe means that transactions can only be modified if all previous outputs are fully spent. This prevents double spends.
+2. Many wallets don't have spare inputs to spend, so they simply can't
+   use FSS-RBF.
 
-The problem with FSS is when you spend money you are signing the "change" (think like quarters, nickles, type change) over back to yourself.
-
-Since FSS requires that change output to be fully spent as well, you might not have any money to add to the transaction.
-
-That's the reason why FSS isn't seen as useful, but that's not the reason the core devs didn't jump straight for it.
-
-The Core devs want to use Opt-in RBF to "compress" transactions and FSS-RBF Doesn't allow that.
-
-To elaborate, FSS-RBF (1) results in larger transactions because you must add a new input rather than just adjust your change output, and (2) is a wallet implementor's nightmare to get right because it involves merging coins to update a fee. If you care about privacy and/or keeping sources of coins separate to defeat block chain analysis, FSS-RBF requires keeping pools of UTXOs available to update fees.
+2. It reduces privacy because it almost always increases the value of
+   the change output, publicly marking that output as change.
 
 ## What is "Child pays for parent" (CPFP)?
 
-### What is it?
-
 Child pays for parent is a way of adding fees to a transaction by making an another transaction that depends on the first.
 
-### Why wasn't it used for RBF?
+## Why wasn't CPFP used for RBF?
 
-It doesn't solve the same problem. Core devs are looking for compressing transactions, not necessarily adding fees alone.
+Child Pays For Parent (CPFP) doesn't solve the same problem.  RBF allows
+the *spender* to increase fees; CPFP is useful because it allows the
+*recipient* to increase fees.
 
-Well specifically adding fees and compressing transactions, and Greg Maxwell don't like CPFP as much because it requires a separate transaction.
+RBF has the advantage over CPFP that it doesn't necessarily require
+using any extra block space, so it's more efficient by about [30% to
+90%](http://lists.linuxfoundation.org/pipermail/bitcoin-dev/2015-May/008232.html).
 
-Both RBF and CPFP will end up being used.
-
-Quoting from Peter Todd's email to the developer [mailing list](http://lists.linuxfoundation.org/pipermail/bitcoin-dev/2015-May/008232.html)
-
-**tl;dr Cost savings by using replace-by-fee, 30-90%**
-
-CPFP is a significantly more expensive way of paying fees than RBF,
-particularly for the use-case of defragmenting outputs, with cost
-savings ranging from 30% to 90%
-
-####Case 1: CPFP vs. RBF for increasing the fee on a single tx
-
-Creating an spending a P2PKH output uses 34 bytes of txout, and 148
-bytes of txin, 182 bytes total.
-
-Let's suppose I have a 1 BTC P2PKH output and I want to pay 0.1 BTC to
-Alice. This results in a 1in/2out transaction t1 that's 226 bytes in size.
-I forget to click on the "priority fee" option, so it goes out with the
-minimum fee of 2.26uBTC. Whoops! I use CPFP to spend that output,
-creating a new transaction t2 that's 192 bytes in size. I want to pay
-1mBTC/KB for a fast confirmation, so I'm now paying 418uBTC of
-transaction fees.
-
-On the other hand, had I use RBF, my wallet would have simply
-rebroadcast t1 with the change address decreased. The rules require you
-to pay 2.26uBTC for the bandwidth consumed broadcasting it, plus the new
-fee level, or 218uBTC of fees in total.
-
-Cost savings: 48%
-
-####Case 2: Paying multiple recipients in succession
-
-Suppose that after I pay Alice, I also decide to pay Bob for his hard
-work demonstrating cryptographic protocols. I need to create a new
-transaction t2 spending t1's change address. Normally t2 would be
-another 226 bytes in size, resulting in 226uBTC additional fees.
-
-With RBF on the other hand I can simply double-spend t1 with a
-transaction paying both Alice and Bob. This new transaction is 260 bytes
-in size. I have to pay 2.6uBTC additional fees to pay for the bandwidth
-consumed broadcasting it, resulting in an additional 36uBTC of fees.
-
-Cost savings: 84%
-
-
-#### Case 3: Paying multiple recipients from a 2-of-3 multisig wallet
-
-The above situation gets even worse with multisig. t1 in the multisig
-case is 367 bytes; t2 another 367 bytes, costing an additional 367uBTC
-in fees. With RBF we rewrite t1 with an additional output, resulting in
-a 399 byte transaction, with just 36uBTC in additional fees.
-
-Cost savings: 90%
-
-####Case 4: Dust defragmentation
-
-My wallet has a two transaction outputs that it wants to combine into
-one for the purpose of UTXO defragmentation. It broadcasts transaction
-t1 with two inputs and one output, size 340 bytes, paying zero fees.
-
-Prior to the transaction confirming I find I need to spend those funds
-for a priority transaction at the 1mBTC/KB fee level. This transaction,
-t2a, has one input and two outputs, 226 bytes in size. However it needs
-to pay fees for both transactions at once, resulting in a combined total
-fee of 556uBTC. If this situation happens frequently, defragmenting
-UTXOs is likely to cost more in additional fees than it saves.
-
-With RBF I'd simply doublespend t1 with a 2-in-2-out transaction 374
-bytes in size, paying 374uBTC. Even better, if one of the two inputs is
-sufficiently large to cover my costs I can doublespend t1 with a
-1-in-2-out tx just 226 bytes in size, paying 226uBTC.
-
-Cost savings: 32% to 59%, or even infinite if defragmentation w/o RBF
-              costs you more than you save
+The plan is to support both CPFP and opt-in RBF.


### PR DESCRIPTION
Major changes:
- All "I" statements either removed or changed to "we" statements.
- Extended quote from Peter Todd email at end removed; in it's place is
  a one sentence summary with a link to the original email
